### PR TITLE
add scopes within boxes, vectors, hashes, and prefab structs

### DIFF
--- a/superscripts.rkt
+++ b/superscripts.rkt
@@ -1,6 +1,7 @@
 #lang racket
 
 (require racket/syntax
+         racket/struct
          racket/string
          racket/format
          debug-scopes/named-scopes-sli-parameter)
@@ -114,6 +115,16 @@
     [(syntax? e) (datum->syntax e (add-scopes (syntax-e e)) e e)]
     [(pair? e) (cons (add-scopes (car e))
                      (add-scopes (cdr e)))]
+    [(box? e)
+     (box-immutable (add-scopes (unbox e)))]
+    [(vector? e)
+     (apply vector-immutable (map add-scopes (vector->list e)))]
+    [(hash? e)
+     (for/fold ([e e]) ([k (in-hash-keys e)])
+       (hash-update e k add-scopes))]
+    [(prefab-struct-key e)
+      (define key (prefab-struct-key e))
+      (apply make-prefab-struct key (map add-scopes (struct->list e)))]
     [else e]))
 
 (define (sli/use whole-stx)


### PR DESCRIPTION
This adds the superscript scope markers within other containers which might be found inside syntax objects.

This changes an output like this:
```racket
(#%sig⁷₈⁹₁₀⁴₁₁¹⁵₁₆ #hash((T . T)) #hash((T . (#%type-decl (#%opaque)))))
```
Into an output like this:
```racket
(#%sig⁵₆²₇¹¹₁₂ #hash((T . T¹³₁₄¹⁵₂⁷₃¹¹₁₆¹⁷)) #hash((T . (#%type-decl⁵₆²₇¹¹₁₂¹⁷ (#%opaque⁵₆²₇¹¹₁₂¹⁷)))))
```