### PR TITLE
use pretty-printing in +scopes

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,7 @@
 #lang info
 (define collection "debug-scopes")
 (define deps '("base"
+               "pretty-format"
                "rackunit-lib"
                "reprovide-lang"))
 (define build-deps '("scribble-lib"

--- a/superscripts.rkt
+++ b/superscripts.rkt
@@ -4,6 +4,7 @@
          racket/struct
          racket/string
          racket/format
+         pretty-format
          debug-scopes/named-scopes-sli-parameter)
 
 (provide +scopes print-full-scopes)
@@ -160,9 +161,9 @@
       ""))
 
 (define (+scopes stx)
-  (format "~a~a"
-          (syntax->datum (add-scopes stx))
-          (sli/use stx)))
+  (pretty-format "~a~a"
+                 (syntax->datum (add-scopes stx))
+                 (sli/use stx)))
 
 #;(define-syntax (foo stx)
     (displayln (+scopes stx))


### PR DESCRIPTION
This makes complex expressions print with pretty-printing's indentation, changing something like this:
```racket
(#%pi-sig⁵₆⁴⁹₆₉⁷²₈₀ ((M1827⁸⁵˙˙⁸⁶ (#%sig⁵₆¹⁵₅₆⁴⁹₆₉⁷⁵₈₀ #hash((X . X¹³₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷) (x . x⁵⁹₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷)) #hash((X . (#%type-decl⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷ (#%opaque⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷))) (x . (#%val-decl⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷ X¹³₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷)))))) (#%sig⁵₆⁴⁹₇₃⁷⁷₈₀⁸⁵ #hash((v . v⁵⁹₁₄¹⁵₄₉⁶⁹₇₃⁷⁸₇₉⁸⁰₈₅⁸⁸)) #hash((v . (#%val-decl⁵₆⁴⁹₇₃⁷⁷₇₉⁸⁰₈₅⁸⁸ (#%dot_τ²³˙˙²⁴ M1827⁸⁵˙˙⁸⁶ X²³˙˙²⁴))))))ˢˡⁱ⁼⁴⁹⁺ᵘˢᵉ⁼
```
to this:
```racket
(#%pi-sig⁵₆⁴⁹₆₉⁷²₈₀
 ((M1827⁸⁵˙˙⁸⁶
   (#%sig⁵₆¹⁵₅₆⁴⁹₆₉⁷⁵₈₀
    #hash((X . X¹³₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷) (x . x⁵⁹₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷))
    #hash((X
           .
           (#%type-decl⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷ (#%opaque⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷)))
          (x . (#%val-decl⁵₆¹⁵₅₆⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷ X¹³₁₄¹⁵₆₀⁶¹₄₉⁶⁹₇₅⁷⁶₈₀⁸⁷))))))
 (#%sig⁵₆⁴⁹₇₃⁷⁷₈₀⁸⁵
  #hash((v . v⁵⁹₁₄¹⁵₄₉⁶⁹₇₃⁷⁸₇₉⁸⁰₈₅⁸⁸))
  #hash((v
         .
         (#%val-decl⁵₆⁴⁹₇₃⁷⁷₇₉⁸⁰₈₅⁸⁸ (#%dot_τ²³˙˙²⁴ M1827⁸⁵˙˙⁸⁶ X²³˙˙²⁴))))))ˢˡⁱ⁼⁴⁹⁺ᵘˢᵉ⁼
```