### PR TITLE
doc: replace undefined module name

### DIFF
--- a/scribblings/debug-scopes.scrbl
+++ b/scribblings/debug-scopes.scrbl
@@ -43,7 +43,8 @@
 
  (foo (list 123))]
 
- When using @racketmodname[debug-scopes/named-scopes], a named scope is often
+ When using named scopes---for example, via
+ @racketmodname[debug-scopes/named-scopes/override]---a named scope is often
  used instead of the macro scope flipped by @racket[syntax-local-introduce]. If
  @racket[+scopes] is called within that context, it also annotates the whole
  expression with the named scope which acts as a replacement for the macro


### PR DESCRIPTION
Replace `debug-scopes/named-scopes` with one of the two documented
 "sub" modules.

[[ Maybe the other one (`debug-scopes/exptime`) is a better choice, and
maybe the paragraph should be reworded further, and
maybe `debug-scopes/named-scopes` should exist ]]
